### PR TITLE
Replace host-breakout communication with 8b10b scheme

### DIFF
--- a/gateware/breakout.v
+++ b/gateware/breakout.v
@@ -85,6 +85,7 @@ reg d_in_clk;
 
 // D_INs with pullup applied
 wire [7:0] d_in_pu;
+wire [7:0] d_in_sync;
 
 // Main system clock
 // ---------------------------------------------------------------
@@ -138,7 +139,7 @@ user_io # (
 breakout_to_host b2h (
     .i_clk(sys_clk),
     .i_clk_s(LVDS_IN[0]),
-    .i_port(d_in_pu),
+    .i_port(d_in_sync),
     .i_button(buttons),
     .i_link_pow(link_pow),
     .o_port_samp_clk(d_in_clk),
@@ -221,6 +222,15 @@ assign USBPU = 0;
 // Digital inputs are sampled on the falling edge of lvds_out
 // The result is packed on the rising edge to avoid metastability
 
+// Digital input synchronizer and i_capture_clk
+//----------------------------------------------------------------
+digital_in_sync_capture dsync (
+    .i_clk(sys_clk),
+    .i_capture_clk(d_in_clk),
+    .i_d(d_in_pu),
+    .o_d(d_in_sync)
+  );
+
 // Enable pullups on the digital input port
 SB_IO # (
     .PIN_TYPE(6'b 0000_00),
@@ -229,7 +239,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN0),
     .D_IN_0(d_in_pu[0]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -239,7 +249,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN1),
     .D_IN_0(d_in_pu[1]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -249,7 +259,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN2),
     .D_IN_0(d_in_pu[2]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -259,7 +269,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN3),
     .D_IN_0(d_in_pu[3]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -269,7 +279,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN4),
     .D_IN_0(d_in_pu[4]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -279,7 +289,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN5),
     .D_IN_0(d_in_pu[5]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -289,7 +299,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN6),
     .D_IN_0(d_in_pu[6]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 SB_IO # (
@@ -299,7 +309,7 @@ SB_IO # (
     .PACKAGE_PIN(D_IN7),
     .D_IN_0(d_in_pu[7]),
     .CLOCK_ENABLE(1'b1),
-    .INPUT_CLK(d_in_clk)
+    .INPUT_CLK(sys_clk)
 );
 
 // Debugger

--- a/gateware/breakout_to_host.v
+++ b/gateware/breakout_to_host.v
@@ -1,25 +1,25 @@
 // serialized output q0: [X, X, but5, ...., but1, but0, pow0, pow1]
 // serialized output q1: [din7, ...., din1, din0, pow2, pow3]
 
+//This module transmits data through 2 serialized lines transmitting 16-bits
+//words using 8b/10b, plus a control code, for a total of 30 coded bits at 60MHz
+//This results in 2MHz per line. However, digital inputs are sent in both lines, sampled
+//at an offset, so digital input bandwidth can be 4MHz, while button and power status is 2MHz
+//
+//Data words are:
+//D0: [din7, ..., din1, din0, X, X, but5, ..., but1, but0]
+//D1: [din7, ..., din1, din0, X, X, X, X, pow3, pow2, pow1, pow0]
+
 `include "clk_div.v"
 
 module breakout_to_host (
 
-    // Main clock coming from host, used to generate i_clk_s Using this to
-    // latch data inputs allows sampling to be synchronous with output updates
-    // in host_to_breakout
-    input   wire        i_clk_s,
-
-    // 0.5 the frequency of underlying data clock
-    input   wire        i_clk, // Full round robin is i_clk * 2 / 10.
+    input   wire        i_clk,
 
     // Parallel inputs
     input   wire [7:0]  i_port,
     input   wire [5:0]  i_button,
     input   wire [3:0]  i_link_pow,
-
-    // Clock to sample i_port
-    output  wire        o_port_samp_clk,
 
     // Serial outputs (2x i_clk frequency due to DDR)
     output  wire        o_clk_s,
@@ -27,83 +27,82 @@ module breakout_to_host (
     output  wire        o_d1_s
 );
 
-// Port sampling
-reg [7:0]  port;
-reg [5:0]  button;
-reg [3:0]  link_pow;
+wire d0_s, d1_s;
+wire d0_reset, d1_reset;
+reg [15:0] d0_data;
+reg [15:0] d1_data;
+wire d0_data_rq, d1_data_rq;
 
-always @ (posedge i_clk_s) begin
-    port <= i_port;
-    button <= i_button;
-    link_pow <= i_link_pow;
+//Reset sequence. Since each transmission takes 30 cycles, we can sample the digital
+//inputs at twice the speed by starting both lines with a 15 cycle offset
+reg [4:0] count;
+initial begin
+  count <= 5'b0;
+end
+always @(posedge i_clk)
+begin
+  if (count < 5'd20) count <= count + 1'b1;
+end
+//Start the first line at 5 cycles, to give time to other parts to start producing data
+assign d0_reset = (count < 5) ? 1'b1 : 1'b0;
+//Start the second line 15 cycles after that
+assign d1_reset = (count < 20) ? 1'b1 : 1'b0;
+
+lvds_8b10b_send #(
+  .NUM_BYTES(NUM_BYTES)
+  ) d0 (
+    .clk(i_clk),
+    .reset(d0_reset),
+    .data(d0_data),
+    .data_read_o(d0_data_rq),
+    .serial_o(d0_s)
+    );
+
+  lvds_8b10b_send #(
+    .NUM_BYTES(NUM_BYTES)
+    ) d1 (
+      .clk(i_clk),
+      .reset(d1_reset),
+      .data(d1_data),
+      .data_read_o(d1_data_rq),
+      .serial_o(d1_s)
+      );
+
+//Port sampling
+always @(posedge i_clk)
+begin
+  if (d0_data_rq) begin
+    d0_data <= {port, 2'b00, button};
+  end
+
+  if (d1_data_rq) begin
+    d1_data <= {port, 4'b0000, link_pow};
+  end
 end
 
-// Shifted, parallel words
-reg [9:0] shift_d0;
-reg [9:0] shift_d1;
-
-// Frame clock
-reg [9:0] shift_clk = 10'b1111100000;
-reg state = 0;
-
-// Out of phase with the DDR output clock
-assign o_port_samp_clk = shift_clk[4];
-
-// Shift out serialized data and clock 2 bits at a time
-always @ (posedge i_clk) begin
-
-    if (shift_clk == 10'b0011111000) begin // new sample
-
-        shift_d0 <= {2'b00, button, link_pow[1:0]};
-        shift_d1 <= {port, link_pow[3:2]};
-        state <= 1;
-
-    end else begin // 2 bits at time for DDR
-
-        shift_d0 <= {shift_d0[7:0], 2'b00};
-        shift_d1 <= {shift_d1[7:0], 2'b00};
-        state <= 0;
-
-    end
-
-    shift_clk <= {shift_clk[7:0], shift_clk[9:8]};
-end
-
-// Final serialized stream using DDR output drivers
+//Simple unregistered output buffers
 SB_IO # (
-    .PIN_TYPE(6'b010000),
+    .PIN_TYPE(6'b011000),
     .IO_STANDARD("SB_LVCMOS")
 ) clk_ddr (
     .PACKAGE_PIN(o_clk_s),
-    .CLOCK_ENABLE(1'b1),
-    .OUTPUT_CLK(i_clk),
-    .OUTPUT_ENABLE(1'b1),
-    .D_OUT_0(shift_clk[8]),
-    .D_OUT_1(shift_clk[9])
+    .D_OUT_0(i_clk)
 );
 
 SB_IO # (
-    .PIN_TYPE(6'b010000),
+    .PIN_TYPE(6'b011000),
     .IO_STANDARD("SB_LVCMOS")
 ) d0_ddr (
     .PACKAGE_PIN(o_d0_s),
-    .CLOCK_ENABLE(1'b1),
-    .OUTPUT_CLK(i_clk),
-    .OUTPUT_ENABLE(1'b1),
-    .D_OUT_0(shift_d0[8]),
-    .D_OUT_1(shift_d0[9])
+    .D_OUT_0(d0_s)
 );
 
 SB_IO # (
-    .PIN_TYPE(6'b010000),
+    .PIN_TYPE(6'b011000),
     .IO_STANDARD("SB_LVCMOS")
 ) d1_ddr (
     .PACKAGE_PIN(o_d1_s),
-    .CLOCK_ENABLE(1'b1),
-    .OUTPUT_CLK(i_clk),
-    .OUTPUT_ENABLE(1'b1),
-    .D_OUT_0(shift_d1[8]),
-    .D_OUT_1(shift_d1[9])
+    .D_OUT_0(d1_s)
 );
 
 endmodule

--- a/gateware/decode8b10b.v
+++ b/gateware/decode8b10b.v
@@ -1,0 +1,165 @@
+// Chuck Benz, Hollis, NH   Copyright (c)2002
+//
+// The information and description contained herein is the
+// property of Chuck Benz.
+//
+// Permission is granted for any reuse of this information
+// and description as long as this copyright notice is
+// preserved.  Modifications may be made as long as this
+// notice is preserved.
+
+// per Widmer and Franaszek
+
+module decode8b10b (datain, dispin, dataout, dispout, code_err, disp_err) ;
+  input [9:0]   datain ;
+  input		dispin ;
+  output [8:0]	dataout ;
+  output	dispout ;
+  output	code_err ;
+  output	disp_err ;
+
+  wire ai = datain[0] ;
+  wire bi = datain[1] ;
+  wire ci = datain[2] ;
+  wire di = datain[3] ;
+  wire ei = datain[4] ;
+  wire ii = datain[5] ;
+  wire fi = datain[6] ;
+  wire gi = datain[7] ;
+  wire hi = datain[8] ;
+  wire ji = datain[9] ;
+
+  wire aeqb = (ai & bi) | (!ai & !bi) ;
+  wire ceqd = (ci & di) | (!ci & !di) ;
+  wire p22 = (ai & bi & !ci & !di) |
+	     (ci & di & !ai & !bi) |
+	     ( !aeqb & !ceqd) ;
+  wire p13 = ( !aeqb & !ci & !di) |
+	     ( !ceqd & !ai & !bi) ;
+  wire p31 = ( !aeqb & ci & di) |
+	     ( !ceqd & ai & bi) ;
+
+  wire p40 = ai & bi & ci & di ;
+  wire p04 = !ai & !bi & !ci & !di ;
+
+  wire disp6a = p31 | (p22 & dispin) ; // pos disp if p22 and was pos, or p31.
+   wire disp6a2 = p31 & dispin ;  // disp is ++ after 4 bits
+   wire disp6a0 = p13 & ! dispin ; // -- disp after 4 bits
+
+  wire disp6b = (((ei & ii & ! disp6a0) | (disp6a & (ei | ii)) | disp6a2 |
+		  (ei & ii & di)) & (ei | ii | di)) ;
+
+  // The 5B/6B decoding special cases where ABCDE != abcde
+
+  wire p22bceeqi = p22 & bi & ci & (ei == ii) ;
+  wire p22bncneeqi = p22 & !bi & !ci & (ei == ii) ;
+  wire p13in = p13 & !ii ;
+  wire p31i = p31 & ii ;
+  wire p13dei = p13 & di & ei & ii ;
+  wire p22aceeqi = p22 & ai & ci & (ei == ii) ;
+  wire p22ancneeqi = p22 & !ai & !ci & (ei == ii) ;
+  wire p13en = p13 & !ei ;
+  wire anbnenin = !ai & !bi & !ei & !ii ;
+  wire abei = ai & bi & ei & ii ;
+  wire cdei = ci & di & ei & ii ;
+  wire cndnenin = !ci & !di & !ei & !ii ;
+
+  // non-zero disparity cases:
+  wire p22enin = p22 & !ei & !ii ;
+  wire p22ei = p22 & ei & ii ;
+  //wire p13in = p12 & !ii ;
+  //wire p31i = p31 & ii ;
+  wire p31dnenin = p31 & !di & !ei & !ii ;
+  //wire p13dei = p13 & di & ei & ii ;
+  wire p31e = p31 & ei ;
+
+  wire compa = p22bncneeqi | p31i | p13dei | p22ancneeqi |
+		p13en | abei | cndnenin ;
+  wire compb = p22bceeqi | p31i | p13dei | p22aceeqi |
+		p13en | abei | cndnenin ;
+  wire compc = p22bceeqi | p31i | p13dei | p22ancneeqi |
+		p13en | anbnenin | cndnenin ;
+  wire compd = p22bncneeqi | p31i | p13dei | p22aceeqi |
+		p13en | abei | cndnenin ;
+  wire compe = p22bncneeqi | p13in | p13dei | p22ancneeqi |
+		p13en | anbnenin | cndnenin ;
+
+  wire ao = ai ^ compa ;
+  wire bo = bi ^ compb ;
+  wire co = ci ^ compc ;
+  wire do = di ^ compd ;
+  wire eo = ei ^ compe ;
+
+  wire feqg = (fi & gi) | (!fi & !gi) ;
+  wire heqj = (hi & ji) | (!hi & !ji) ;
+  wire fghj22 = (fi & gi & !hi & !ji) |
+		(!fi & !gi & hi & ji) |
+		( !feqg & !heqj) ;
+  wire fghjp13 = ( !feqg & !hi & !ji) |
+		 ( !heqj & !fi & !gi) ;
+  wire fghjp31 = ( (!feqg) & hi & ji) |
+		 ( !heqj & fi & gi) ;
+
+  wire dispout = (fghjp31 | (disp6b & fghj22) | (hi & ji)) & (hi | ji) ;
+
+  wire ko = ( (ci & di & ei & ii) | ( !ci & !di & !ei & !ii) |
+		(p13 & !ei & ii & gi & hi & ji) |
+		(p31 & ei & !ii & !gi & !hi & !ji)) ;
+
+  wire alt7 =   (fi & !gi & !hi & // 1000 cases, where disp6b is 1
+		 ((dispin & ci & di & !ei & !ii) | ko |
+		  (dispin & !ci & di & !ei & !ii))) |
+		(!fi & gi & hi & // 0111 cases, where disp6b is 0
+		 (( !dispin & !ci & !di & ei & ii) | ko |
+		  ( !dispin & ci & !di & ei & ii))) ;
+
+  wire k28 = (ci & di & ei & ii) | ! (ci | di | ei | ii) ;
+  // k28 with positive disp into fghi - .1, .2, .5, and .6 special cases
+  wire k28p = ! (ci | di | ei | ii) ;
+  wire fo = (ji & !fi & (hi | !gi | k28p)) |
+	    (fi & !ji & (!hi | gi | !k28p)) |
+	    (k28p & gi & hi) |
+	    (!k28p & !gi & !hi) ;
+  wire go = (ji & !fi & (hi | !gi | !k28p)) |
+	    (fi & !ji & (!hi | gi |k28p)) |
+	    (!k28p & gi & hi) |
+	    (k28p & !gi & !hi) ;
+  wire ho = ((ji ^ hi) & ! ((!fi & gi & !hi & ji & !k28p) | (!fi & gi & hi & !ji & k28p) |
+			    (fi & !gi & !hi & ji & !k28p) | (fi & !gi & hi & !ji & k28p))) |
+	    (!fi & gi & hi & ji) | (fi & !gi & !hi & !ji) ;
+
+  wire disp6p = (p31 & (ei | ii)) | (p22 & ei & ii) ;
+  wire disp6n = (p13 & ! (ei & ii)) | (p22 & !ei & !ii) ;
+  wire disp4p = fghjp31 ;
+  wire disp4n = fghjp13 ;
+
+  assign code_err = p40 | p04 | (fi & gi & hi & ji) | (!fi & !gi & !hi & !ji) |
+		    (p13 & !ei & !ii) | (p31 & ei & ii) |
+		    (ei & ii & fi & gi & hi) | (!ei & !ii & !fi & !gi & !hi) |
+		    (ei & !ii & gi & hi & ji) | (!ei & ii & !gi & !hi & !ji) |
+		    (!p31 & ei & !ii & !gi & !hi & !ji) |
+		    (!p13 & !ei & ii & gi & hi & ji) |
+		    (((ei & ii & !gi & !hi & !ji) |
+		      (!ei & !ii & gi & hi & ji)) &
+		     ! ((ci & di & ei) | (!ci & !di & !ei))) |
+		    (disp6p & disp4p) | (disp6n & disp4n) |
+		    (ai & bi & ci & !ei & !ii & ((!fi & !gi) | fghjp13)) |
+		    (!ai & !bi & !ci & ei & ii & ((fi & gi) | fghjp31)) |
+		    (fi & gi & !hi & !ji & disp6p) |
+		    (!fi & !gi & hi & ji & disp6n) |
+		    (ci & di & ei & ii & !fi & !gi & !hi) |
+		    (!ci & !di & !ei & !ii & fi & gi & hi) ;
+
+  assign dataout = {ko, ho, go, fo, eo, do, co, bo, ao} ;
+
+  // my disp err fires for any legal codes that violate disparity, may fire for illegal codes
+   assign disp_err = ((dispin & disp6p) | (disp6n & !dispin) |
+		      (dispin & !disp6n & fi & gi) |
+		      (dispin & ai & bi & ci) |
+		      (dispin & !disp6n & disp4p) |
+		      (!dispin & !disp6p & !fi & !gi) |
+		      (!dispin & !ai & !bi & !ci) |
+		      (!dispin & !disp6p & disp4n) |
+		      (disp6p & disp4p) | (disp6n & disp4n)) ;
+
+endmodule

--- a/gateware/digital_in_sync.v
+++ b/gateware/digital_in_sync.v
@@ -1,6 +1,5 @@
-module digital_in_sync_capture (
+module digital_in_sync (
     input wire i_clk,
-    input wire i_capture_clk,
 
     input wire [7:0] i_d,
     output wire [7:0] o_d
@@ -19,9 +18,6 @@ module digital_in_sync_capture (
     sync[1] <= i_d;
   end
 
-  always @(negedge i_capture_clk)
-  begin
-    o_d <= sync[0];
-  end
+  assign o_d = sync[0];
 
   endmodule

--- a/gateware/digital_in_sync_capture.v
+++ b/gateware/digital_in_sync_capture.v
@@ -1,0 +1,27 @@
+module digital_in_sync_capture (
+    input wire i_clk,
+    input wire i_capture_clk,
+
+    input wire [7:0] i_d,
+    output wire [7:0] o_d
+  );
+
+  reg [7:0] sync[1:0];
+
+  initial begin
+    sync[0] <= 8'h00;
+    sync[1] <= 8'h00;
+  end
+
+  always @(posedge i_clk)
+  begin
+    sync[0] <= sync[1];
+    sync[1] <= i_d;
+  end
+
+  always @(negedge i_capture_clk)
+  begin
+    o_d <= sync[0];
+  end
+
+  endmodule

--- a/gateware/encode8b10b.v
+++ b/gateware/encode8b10b.v
@@ -1,0 +1,120 @@
+// Chuck Benz, Hollis, NH   Copyright (c)2002
+//
+// The information and description contained herein is the
+// property of Chuck Benz.
+//
+// Permission is granted for any reuse of this information
+// and description as long as this copyright notice is
+// preserved.  Modifications may be made as long as this
+// notice is preserved.
+
+// per Widmer and Franaszek
+
+module encode8b10b (datain, dispin, dataout, dispout) ;
+  input [8:0]   datain ;
+  input 	dispin ;  // 0 = neg disp; 1 = pos disp
+  output [9:0]	dataout ;
+  output	dispout ;
+
+
+  wire ai = datain[0] ;
+  wire bi = datain[1] ;
+  wire ci = datain[2] ;
+  wire di = datain[3] ;
+  wire ei = datain[4] ;
+  wire fi = datain[5] ;
+  wire gi = datain[6] ;
+  wire hi = datain[7] ;
+  wire ki = datain[8] ;
+
+  wire aeqb = (ai & bi) | (!ai & !bi) ;
+  wire ceqd = (ci & di) | (!ci & !di) ;
+  wire l22 = (ai & bi & !ci & !di) |
+	     (ci & di & !ai & !bi) |
+	     ( !aeqb & !ceqd) ;
+  wire l40 = ai & bi & ci & di ;
+  wire l04 = !ai & !bi & !ci & !di ;
+  wire l13 = ( !aeqb & !ci & !di) |
+	     ( !ceqd & !ai & !bi) ;
+  wire l31 = ( !aeqb & ci & di) |
+	     ( !ceqd & ai & bi) ;
+
+  // The 5B/6B encoding
+
+  wire ao = ai ;
+  wire bo = (bi & !l40) | l04 ;
+  wire co = l04 | ci | (ei & di & !ci & !bi & !ai) ;
+  wire do = di & ! (ai & bi & ci) ;
+  wire eo = (ei | l13) & ! (ei & di & !ci & !bi & !ai) ;
+  wire io = (l22 & !ei) |
+	    (ei & !di & !ci & !(ai&bi)) |  // D16, D17, D18
+	    (ei & l40) |
+	    (ki & ei & di & ci & !bi & !ai) | // K.28
+	    (ei & !di & ci & !bi & !ai) ;
+
+  // pds16 indicates cases where d-1 is assumed + to get our encoded value
+  wire pd1s6 = (ei & di & !ci & !bi & !ai) | (!ei & !l22 & !l31) ;
+  // nds16 indicates cases where d-1 is assumed - to get our encoded value
+  wire nd1s6 = ki | (ei & !l22 & !l13) | (!ei & !di & ci & bi & ai) ;
+
+  // ndos6 is pds16 cases where d-1 is + yields - disp out - all of them
+  wire ndos6 = pd1s6 ;
+  // pdos6 is nds16 cases where d-1 is - yields + disp out - all but one
+  wire pdos6 = ki | (ei & !l22 & !l13) ;
+
+
+  // some Dx.7 and all Kx.7 cases result in run length of 5 case unless
+  // an alternate coding is used (referred to as Dx.A7, normal is Dx.P7)
+  // specifically, D11, D13, D14, D17, D18, D19.
+  wire alt7 = fi & gi & hi & (ki |
+			      (dispin ? (!ei & di & l31) : (ei & !di & l13))) ;
+
+
+  wire fo = fi & ! alt7 ;
+  wire go = gi | (!fi & !gi & !hi) ;
+  wire ho = hi ;
+  wire jo = (!hi & (gi ^ fi)) | alt7 ;
+
+  // nd1s4 is cases where d-1 is assumed - to get our encoded value
+  wire nd1s4 = fi & gi ;
+  // pd1s4 is cases where d-1 is assumed + to get our encoded value
+  wire pd1s4 = (!fi & !gi) | (ki & ((fi & !gi) | (!fi & gi))) ;
+
+  // ndos4 is pd1s4 cases where d-1 is + yields - disp out - just some
+  wire ndos4 = (!fi & !gi) ;
+  // pdos4 is nd1s4 cases where d-1 is - yields + disp out
+  wire pdos4 = fi & gi & hi ;
+
+  // only legal K codes are K28.0->.7, K23/27/29/30.7
+  //	K28.0->7 is ei=di=ci=1,bi=ai=0
+  //	K23 is 10111
+  //	K27 is 11011
+  //	K29 is 11101
+  //	K30 is 11110 - so K23/27/29/30 are ei & l31
+  wire illegalk = ki &
+		  (ai | bi | !ci | !di | !ei) & // not K28.0->7
+		  (!fi | !gi | !hi | !ei | !l31) ; // not K23/27/29/30.7
+
+  // now determine whether to do the complementing
+  // complement if prev disp is - and pd1s6 is set, or + and nd1s6 is set
+  wire compls6 = (pd1s6 & !dispin) | (nd1s6 & dispin) ;
+
+  // disparity out of 5b6b is disp in with pdso6 and ndso6
+  // pds16 indicates cases where d-1 is assumed + to get our encoded value
+  // ndos6 is cases where d-1 is + yields - disp out
+  // nds16 indicates cases where d-1 is assumed - to get our encoded value
+  // pdos6 is cases where d-1 is - yields + disp out
+  // disp toggles in all ndis16 cases, and all but that 1 nds16 case
+
+  wire disp6 = dispin ^ (ndos6 | pdos6) ;
+
+  wire compls4 = (pd1s4 & !disp6) | (nd1s4 & disp6) ;
+  assign dispout = disp6 ^ (ndos4 | pdos4) ;
+
+  assign dataout = {(jo ^ compls4), (ho ^ compls4),
+		    (go ^ compls4), (fo ^ compls4),
+		    (io ^ compls6), (eo ^ compls6),
+		    (do ^ compls6), (co ^ compls6),
+		    (bo ^ compls6), (ao ^ compls6)} ;
+
+endmodule

--- a/gateware/lvds_8b10b_receive.v
+++ b/gateware/lvds_8b10b_receive.v
@@ -1,0 +1,182 @@
+module lvds_8b10b_receive #(
+    parameter NUM_BYTES = 2,
+    parameter COMMA_CODE = 9'b100111100, //K28.1
+
+    parameter BYTES_COUNT_BITS = $clog2(NUM_BYTES)
+
+  )(
+    input clk,
+    input reset,
+
+    input serial,
+    output reg[8*NUM_BYTES - 1 : 0] data_o = 'b0,
+    output reg data_rdy_o = 1'b0,
+
+    output reg code_err_o = 1'b0,
+    output reg disp_err_o = 1'b0,
+    output reg sync_err_o = 1'b0
+  );
+
+  localparam  COMMA_SEQUENCE = 8'b01111100;
+
+  reg [8:0] received_code;
+  wire[8:0] code_output;
+  reg [9:0] serial_input;
+  reg [9:0] code_input;
+  wire dispout;
+  reg dispin = 1'b0;
+  reg dispin_next = 1'b0;
+  reg dispin_detected = 1'b0;
+  wire code_err;
+  wire disp_err;
+  reg code_err_r = 1'b0;
+  reg disp_err_r = 1'b0;
+  reg sync_err_r = 1'b0;
+
+  reg [3:0] bit_count = 'b0;
+  reg comma = 1'b0;
+  reg [BYTES_COUNT_BITS-1 : 0] cur_byte = 'd0;
+  reg [8*NUM_BYTES - 1 : 0] data = 'b0;
+
+  decode8b10b decoder (
+    .datain(code_input),
+    .dispin(dispin),
+    .dataout(code_output),
+    .dispout(dispout),
+    .code_err(code_err),
+    .disp_err(disp_err)
+  ) ;
+
+  localparam S_WAITSYNC = 3'd0,
+             S_RECVSYNC = 3'd1,
+             S_LATCHSYNC = 3'd2,
+             S_CHECKSYNC = 3'd3,
+             S_RECVBYTE = 3'd4,
+             S_LATCHBYTE = 3'd5,
+             S_CHECKBYTE = 3'd6,
+             S_SEND = 3'd7;
+  reg [2:0] state = S_WAITSYNC;
+
+//serial input and align detect
+  always @(posedge reset or posedge clk)
+  begin
+      if (reset) begin
+        serial_input <= 'b0;
+        bit_count <= 'b0;
+        dispin_detected <= 1'b0;
+        comma <= 1'b0;
+      end else begin
+        serial_input <= {serial, serial_input[9:1]};
+        comma <= 1'b0;
+        if ( {serial, serial_input[9:3]} == COMMA_SEQUENCE && state == S_WAITSYNC) begin
+          comma <= 1'b1;
+          dispin_detected = 1'b0;
+          bit_count <= 4'd8;
+        end else if ( {serial, serial_input[9:3]} == ~COMMA_SEQUENCE && state == S_WAITSYNC) begin
+          comma <= 1'b1;
+          dispin_detected = 1'b1;
+          bit_count <= 4'd8;
+        end else if (bit_count == 4'd9) begin
+          bit_count <= 4'd0;
+        end else begin
+          bit_count <= bit_count + 1'b1;
+        end
+      end
+  end
+
+  //Data output state machine
+  //Since we know that it takes 10 cycles to read a whole code, we can use different states
+  //for decoding and storing data safely
+
+  always @(posedge reset or posedge clk)
+  begin
+    if (reset) begin
+      state <= S_WAITSYNC;
+      data_rdy_o <= 1'b0;
+      code_err_o <= 1'b0;
+      code_err_r <= 1'b0;
+      disp_err_o <= 1'b0;
+      disp_err_r <= 1'b0;
+      sync_err_r <= 1'b0;
+      dispin_next <= 1'b0;
+      cur_byte <= 'b0;
+      data <= 'b0;
+      data_o <= 'b0;
+    end else begin
+      data_rdy_o <= 1'b0;
+      case (state)
+        S_WAITSYNC: begin
+          disp_err_r <= 1'b0;
+          code_err_r <= 1'b0;
+          sync_err_r <= 1'b0;
+          if (comma) begin
+            state <= S_RECVSYNC;
+            dispin_next <= dispin_detected;
+          end
+        end
+      S_RECVSYNC: begin
+        if (bit_count == 4'd0) begin
+          code_input <= serial_input;
+          dispin <= dispin_next;
+          state <= S_LATCHSYNC;
+        end
+      end
+      S_LATCHSYNC: begin
+        if (disp_err == 1'b1) disp_err_r <= 1'b1;
+        if (code_err == 1'b1) code_err_r <= 1'b1;
+        received_code <= code_output;
+        dispin_next <= dispout;
+        state <= S_CHECKSYNC;
+      end
+      S_CHECKSYNC: begin
+        if (received_code != COMMA_CODE) begin //We received an invalid comma code. Send the error and reset
+          sync_err_r <= 1'b1;
+          state <= S_SEND;
+        end else begin
+          state <= S_RECVBYTE;
+          cur_byte <= 'b0;
+        end
+      end
+      S_RECVBYTE: begin
+        if (bit_count == 4'd0) begin
+          code_input <= serial_input;
+          dispin <= dispin_next;
+          state <= S_LATCHBYTE;
+        end
+      end
+      S_LATCHBYTE: begin
+        if (disp_err == 1'b1) disp_err_r <= 1'b1;
+        if (code_err == 1'b1) code_err_r <= 1'b1;
+        received_code <= code_output;
+        dispin_next <= dispout;
+        state <= S_CHECKBYTE;
+      end
+      S_CHECKBYTE: begin
+        if (received_code[8] == 1'b1) begin //unexpected control code. Just reset just in case
+          sync_err_r <= 1'b1;
+          state <= S_SEND;
+        end else begin
+          data[cur_byte*8 +: 8] <= received_code[7:0];
+          if (cur_byte == NUM_BYTES - 1) begin
+            cur_byte <= 'b0;
+            state <= S_SEND;
+          end else begin
+            cur_byte <= cur_byte + 1'b1;
+            state <= S_RECVBYTE;
+          end
+        end
+      end
+      S_SEND: begin
+        disp_err_o <= disp_err_r;
+        code_err_o <= code_err_r;
+        sync_err_o <= sync_err_r;
+        data_o <= data;
+        data_rdy_o <= 1'b1;
+        state <= S_WAITSYNC;
+      end
+      endcase
+    end
+  end
+
+
+  endmodule

--- a/gateware/lvds_8b10b_receive_tb.v
+++ b/gateware/lvds_8b10b_receive_tb.v
@@ -1,0 +1,113 @@
+`timescale 1ns/100ps
+
+module lvds_8b10b_receive_tb ();
+
+  parameter SYSCLK_PERIOD = 20;// 50MHZ
+  reg clk;
+  reg reset;
+
+  initial
+  begin
+      clk = 1'b0;
+      reset = 1'b1;
+  end
+
+  //////////////////////////////////////////////////////////////////////
+  // Reset Pulse
+  //////////////////////////////////////////////////////////////////////
+  initial
+  begin
+      #(SYSCLK_PERIOD * 10 )
+          reset = 1'b0;
+  end
+
+
+  //////////////////////////////////////////////////////////////////////
+  // Clock Driver
+  //////////////////////////////////////////////////////////////////////
+  always @(clk)
+      #(SYSCLK_PERIOD / 2.0) clk <= !clk;
+
+ parameter NUM_BYTES = 2;
+
+ reg [8*NUM_BYTES - 1 : 0] data;
+ wire serial_o;
+ reg serial_i;
+ wire data_read_en;
+
+lvds_8b10b_send #(
+  .NUM_BYTES(NUM_BYTES)
+  ) send (
+    .clk(clk),
+    .reset(reset),
+    .data(data),
+    .data_read_o(data_read_en),
+    .serial_o(serial_o)
+    );
+
+    wire [8*NUM_BYTES - 1 : 0] data_out;
+    wire data_rdy;
+    wire disp_err;
+    wire code_err;
+    wire sync_err;
+
+    lvds_8b10b_receive #(
+      .NUM_BYTES(NUM_BYTES)
+    ) dut (
+      .clk(~clk),
+      .reset(reset),
+      .serial(serial_i),
+      .data_o(data_out),
+      .data_rdy_o(data_rdy),
+      .disp_err_o(disp_err),
+      .code_err_o(code_err),
+      .sync_err_o(sync_err)
+      );
+
+    reg [8*NUM_BYTES - 1 : 0] sample [0:3];
+
+    initial
+    begin
+      sample[0] = 16'h0001;
+      sample[1] = 16'habcd;
+      sample[2] = 16'habcd;
+      sample[3] = 16'hFF67;
+    end
+
+   reg [1:0] count = 'b0;
+   reg [1:0] reps = 'b0;
+   reg [31:0] clkcount = 'b0;
+
+   always @ (posedge clk)
+   begin
+          clkcount <= clkcount + 1'b1;
+          if (reps == 2'd3) $stop;
+          if (data_read_en) begin
+            clkcount <= 'b0;
+            data <= sample[count];
+            if (count == 2'd3) begin
+              count <= 'b0;
+              reps <= reps + 1'b1;
+            end else begin
+              count <= count + 1'b1;
+            end
+          end
+   end
+
+   always @(*) begin
+    serial_i <= #2 serial_o;
+
+    //uncomment for manual alterations
+/*    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd9) serial_i <= 1'b0;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd10) serial_i <= 1'b0;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd11) serial_i <= 1'b0;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd12) serial_i <= 1'b0;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd13) serial_i <= 1'b1;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd14) serial_i <= 1'b1;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd15) serial_i <= 1'b1;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd16) serial_i <= 1'b1;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd17) serial_i <= 1'b0;
+    if (count == 2'd1 && reps == 2'd0 && clkcount == 'd18) serial_i <= 1'b0;*/
+   end
+
+endmodule

--- a/gateware/lvds_8b10b_send.v
+++ b/gateware/lvds_8b10b_send.v
@@ -1,0 +1,86 @@
+module lvds_8b10b_send #(
+    parameter NUM_BYTES = 2,
+    parameter COMMA_CODE = 9'b100111100, //K28.1
+
+    parameter BYTES_COUNT_BITS = $clog2(NUM_BYTES)
+  )(
+    input clk,
+    input reset,
+
+    input [8*NUM_BYTES - 1 : 0] data,
+    output reg data_read_o,
+
+    output reg serial_o
+  );
+
+  localparam FIRST_OUTPUT = 10'b1010101010; //Invalid but 0 disparity code for the first cycle
+
+  reg [8*NUM_BYTES - 1 : 0] data_r = 'b0;
+  reg [BYTES_COUNT_BITS : 0] next_byte = 'd0;
+  reg [3:0] bit_count = 'b0;
+
+  reg [8:0] code_input = COMMA_CODE;
+  reg [8:0] next_code;
+  wire [9:0] code_output;
+  reg [9:0] serial_output = FIRST_OUTPUT;
+
+  reg dispin = 1'b0;
+  reg dispin_next = 1'b0;
+  wire dispout;
+
+  encode8b10b encoder
+  (
+    .datain(code_input),
+    .dispin(dispin),
+    .dataout(code_output),
+    .dispout(dispout)
+  );
+
+  always @(posedge clk or posedge reset)
+  begin
+    if (reset) begin
+      data_r <= 'b0;
+      next_byte <= 'd0;
+      bit_count <= 'b0;
+      code_input <= COMMA_CODE;
+      data_read_o <= 1'b0;
+      dispin <= 1'b0;
+      dispin_next <= 1'b0;
+      serial_output <= FIRST_OUTPUT;
+      serial_o <= 1'b0;
+    end else begin
+      serial_o <= serial_output[bit_count];
+      bit_count <= bit_count + 1'b1;
+      data_read_o <= 1'b0;
+      if (bit_count == 4'd0) begin
+        if (next_byte == 'd1) begin //Latch data on comma symbol using a simple FIFO interface
+          data_read_o <= 1'b1; //Request data
+        end
+      end else if (bit_count == 4'd2) begin
+        if (next_byte == 'd1) begin
+          data_r <= data; //Latch data
+        end
+      end else if (bit_count == 4'd4) begin //begin encoding. This position is arbitrary, so we let a little leeway
+        code_input <= next_code;
+        dispin <= dispin_next;
+      end else if (bit_count == 4'd9) begin
+        bit_count <= 'b0;
+        serial_output <= code_output;
+        dispin_next <= dispout;
+        if (next_byte == NUM_BYTES) next_byte <= 'b0;
+        else next_byte <= next_byte + 1'b1;
+      end
+    end
+  end
+
+  always @(next_byte, data_r)
+  begin
+    if (next_byte == 'b0) begin
+      next_code <= COMMA_CODE;
+    end else begin
+      next_code <= data_r[8*(next_byte-1) +: 8];
+    end
+  end
+
+
+  endmodule

--- a/gateware/lvds_8b10b_send_tb.v
+++ b/gateware/lvds_8b10b_send_tb.v
@@ -1,0 +1,69 @@
+`timescale 1ns/100ps
+
+module lvds_8b10b_send_tb ();
+
+  parameter SYSCLK_PERIOD = 20;// 50MHZ
+  reg clk;
+  reg reset;
+
+  initial
+  begin
+      clk = 1'b0;
+      reset = 1'b1;
+  end
+
+  //////////////////////////////////////////////////////////////////////
+  // Reset Pulse
+  //////////////////////////////////////////////////////////////////////
+  initial
+  begin
+      #(SYSCLK_PERIOD * 10 )
+          reset = 1'b0;
+  end
+
+
+  //////////////////////////////////////////////////////////////////////
+  // Clock Driver
+  //////////////////////////////////////////////////////////////////////
+  always @(clk)
+      #(SYSCLK_PERIOD / 2.0) clk <= !clk;
+
+ parameter NUM_BYTES = 2;
+
+ reg [8*NUM_BYTES - 1 : 0] data;
+ wire data_out;
+ wire data_read;
+
+lvds_8b10b_send #(
+  .NUM_BYTES(NUM_BYTES)
+  ) dut (
+    .clk(clk),
+    .reset(reset),
+    .data(data),
+    .data_read_o(data_read),
+    .serial_o(data_out)
+    );
+
+    reg [8*NUM_BYTES - 1 : 0] sample [0:2];
+
+    initial
+    begin
+      sample[0] = 16'h0001;
+      sample[1] = 16'habcd;
+      sample[2] = 16'habcd;
+    end
+
+   reg [1:0] count = 'b0;
+
+   always @ (posedge clk)
+   begin
+          if (data_read) begin
+            if (count == 2'd3) $stop;
+            else begin
+              data <= sample[count];
+              count <= count + 1'b1;
+            end
+          end
+   end
+
+endmodule


### PR DESCRIPTION
Reduces the data clock to 60MHz and replaces the old communication and synchronization scheme:
- Now the clock line receives a simple, continuous 60MHz clock that is used to capture input data and drive the breakout board
- Likewise, the board just sends this clock back through the output clock line
- Now all data lines use a 8b/10b encoding. In all cases they transmit a K28.1 control byte and two data bytes, resulting in a continuous 30bit stream
- Data structure has been slightly changed on output lines to take advantage of these data widths
- Due to the aligning byte of 8b/10b, streams can now be independent and have not to be aligned
- Thanks to the independent nature, streams are sent shifted 15 clocks, enabling the sample of digital input lines at twice the rate. Can be easily disabled and have the streams sent at the same time.

TODO:
- Replace the input clock (there is a placeholder line) with a proper buffer or PLL
- Testing